### PR TITLE
Serve client assets via FastAPI static files

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -10,7 +10,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
 
@@ -264,6 +264,6 @@
 
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="app.js"></script>
+    <script src="/static/app.js"></script>
   </body>
 </html>

--- a/server/main.py
+++ b/server/main.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.staticfiles import StaticFiles
 from psycopg2.extras import RealDictCursor
 
 from . import db, jobs
@@ -30,6 +31,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.mount("/static", StaticFiles(directory="client"), name="client")
 
 DATA_PATH = Path("data/top100_hs.csv")
 DEFAULT_SOURCE = "database"


### PR DESCRIPTION
## Summary
- mount the FastAPI app with a /static route serving the client directory
- update the client HTML to load CSS/JS via the mounted static path

## Testing
- python -m compileall server
- python -m unittest discover

------
https://chatgpt.com/codex/tasks/task_e_68d2b6431b3c832198a95ddf50782ca9