### PR TITLE
chore: add aiofiles dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psycopg2-binary
 pydantic
 python-dotenv
 python-dateutil
+aiofiles


### PR DESCRIPTION
## Summary
- append aiofiles to the root requirements to satisfy StaticFiles optional dependency

## Testing
- `pip install -r requirements.txt` *(fails: cannot connect to proxy for aiofiles index)*

------
https://chatgpt.com/codex/tasks/task_e_68d37139365883218b420a6f6dba6544